### PR TITLE
	Remove features that have potential negative impact on users. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
-Version 0.0.3
- - Change Python rules to srcs_version = "PY2AND3"
+# Change Log
 
-Version 0.0.2
- - Add PhantomJS browser for Linux.
- - Add support for named files in archives.
- - Add MacOS support for Chrome, Firefox, and PhantomJS browser.
- - Support placeholders for named file paths in capabilities.
- - Use template files to generate test scripts.
- - Add Python Library for use with web_test.
+## Version Next
+
+*   No longer use bind for configuraion. Instead make the rule attributes that
+    depended on these bind statements public.
+*   Remove usages of git_repository.
+*   Make the set of repositories loaded by web_test_repositories fully
+    configurable.
+*   Switch from platform-specific repositories to repositories that get
+    configured based on the current platform.
+
+## Version 0.0.3
+
+*   Change Python rules to srcs_version = "PY2AND3"
+
+## Version 0.0.2
+
+*   Add PhantomJS browser for Linux.
+*   Add support for named files in archives.
+*   Add MacOS support for Chrome, Firefox, and PhantomJS browser.
+*   Support placeholders for named file paths in capabilities.
+*   Use template files to generate test scripts.
+*   Add Python Library for use with web_test.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,11 @@
 #
 workspace(name = "io_bazel_rules_web")
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    remote = "https://github.com/bazelbuild/rules_go.git",
-    tag = "0.2.0",
+    sha256 = "0c0ec7b9c7935883cbfb2df48fbf524e857859a5c05ae1b24d5442956e6bb5e8",
+    strip_prefix = "rules_go-0.2.0",
+    url = "https://github.com/bazelbuild/rules_go/archive/0.2.0.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
@@ -29,15 +30,9 @@ go_repositories()
 load("//web:repositories.bzl", "web_test_repositories")
 
 web_test_repositories(
-    default_config = "//web:default_config",
     go = True,
     java = True,
-    launcher = "//go/launcher:main",
-    merger = "//go/metadata:merger",
-    noop_web_test_template = "//web/internal:noop_web_test.sh.template",
-    prefix = "",
     python = True,
-    web_test_template = "//web/internal:web_test.sh.template",
 )
 
 maven_jar(
@@ -52,82 +47,66 @@ maven_jar(
     sha1 = "b6ad12d98295a7d17b3fe4b8969d0f7905626b30",
 )
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_sass",
-    remote = "https://github.com/bazelbuild/rules_sass.git",
-    tag = "0.0.1",
+    sha256 = "d39d40c39a0fa2c7d05230ccf95aac3628936e4e76c0379ad324ff0b8488160f",
+    strip_prefix = "rules_sass-0.0.1",
+    url = "https://github.com/bazelbuild/rules_sass/archive/0.0.1.tar.gz",
 )
 
 load("@io_bazel_rules_sass//sass:sass.bzl", "sass_repositories")
 
 sass_repositories()
 
-git_repository(
+http_archive(
     name = "io_bazel_skydoc",
-    commit = "c57ff682364dbb1ae808b769f9e3add77cdbfad1",
-    remote = "https://github.com/bazelbuild/skydoc.git",
+    sha256 = "256bf8b64269d21fd46b8696007b5b9ef10070d79c106e74fb37979c04b6d519",
+    strip_prefix = "skydoc-c57ff682364dbb1ae808b769f9e3add77cdbfad1",
+    url = "https://github.com/bazelbuild/skydoc/archive/c57ff682364dbb1ae808b769f9e3add77cdbfad1.tar.gz",
 )
 
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skydoc_repositories")
 
 skydoc_repositories()
 
-http_file(
-    name = "org_chromium_chromedriver_linux",
-    sha256 = "0c01b05276da98f203dc7eb4236c2ee7fe799b432734e088549bd0aadc71958e",
-    url = "http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip",
+load("//web/internal:platform_http_file.bzl", "platform_http_file")
+
+platform_http_file(
+    name = "org_chromium_chromedriver",
+    amd64_sha256 = "0c01b05276da98f203dc7eb4236c2ee7fe799b432734e088549bd0aadc71958e",
+    amd64_url = "http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip",
+    macos_sha256 = "d4f6e13d88ecf20735138f16ab1545e855a42bce41bebe73667a028871777790",
+    macos_url = "http://chromedriver.storage.googleapis.com/2.24/chromedriver_mac64.zip",
 )
 
-http_file(
-    name = "com_google_chrome_linux",
-    sha256 = "6e26d74fd814c38cd419d1ffe87b3e81ad6cfe453e27c7a672ab3c452968e71d",
-    url = "https://commondatastorage.googleapis.com/chrome-unsigned/desktop-5c0tCh/53.0.2785.116/precise64/chrome-precise64.zip",
+platform_http_file(
+    name = "com_google_chrome",
+    amd64_sha256 = "6e26d74fd814c38cd419d1ffe87b3e81ad6cfe453e27c7a672ab3c452968e71d",
+    amd64_url = "https://commondatastorage.googleapis.com/chrome-unsigned/desktop-5c0tCh/53.0.2785.116/precise64/chrome-precise64.zip",
+    macos_sha256 = "84b3cf4f7a9f85fa90dda837b1e38820c83c383fcb6346bbec6448d5128dd7f9",
+    macos_url = "https://commondatastorage.googleapis.com/chrome-unsigned/desktop-5c0tCh/53.0.2785.116/mac64/chrome-mac.zip",
 )
 
-http_file(
-    name = "org_chromium_chromedriver_mac",
-    sha256 = "d4f6e13d88ecf20735138f16ab1545e855a42bce41bebe73667a028871777790",
-    url = "http://chromedriver.storage.googleapis.com/2.24/chromedriver_mac64.zip",
+platform_http_file(
+    name = "org_mozilla_firefox",
+    amd64_sha256 = "95884070af8870a550ef70600793b6e6d5207f34af24f8b437b6c67b095e5517",
+    amd64_url = "https://ftp.mozilla.org/pub/firefox/releases/49.0/firefox-49.0.linux-x86_64.sdk.tar.bz2",
+    macos_sha256 = "c068696c69af2da2b916e33e93755f7dda478fa6e9d17a60643cf2009bbaf8e2",
+    macos_url = "https://ftp.mozilla.org/pub/firefox/releases/49.0/firefox-49.0.mac-x86_64.sdk.tar.bz2",
 )
 
-http_file(
-    name = "com_google_chrome_mac",
-    sha256 = "84b3cf4f7a9f85fa90dda837b1e38820c83c383fcb6346bbec6448d5128dd7f9",
-    url = "https://commondatastorage.googleapis.com/chrome-unsigned/desktop-5c0tCh/53.0.2785.116/mac64/chrome-mac.zip",
+platform_http_file(
+    name = "org_mozilla_geckodriver",
+    amd64_sha256 = "dee64571aefb5ef0279df7358d5f74fdf19a316adbab13c67e3c2d2c14da9e97",
+    amd64_url = "https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz",
+    macos_sha256 = "acb05a7671948167e6c1b6930f32ea71dcaa2c12b2c2963e829c7b232f9125d0",
+    macos_url = "https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-macos.tar.gz",
 )
 
-http_file(
-    name = "org_mozilla_firefox_linux",
-    sha256 = "95884070af8870a550ef70600793b6e6d5207f34af24f8b437b6c67b095e5517",
-    url = "https://ftp.mozilla.org/pub/firefox/releases/49.0/firefox-49.0.linux-x86_64.sdk.tar.bz2",
-)
-
-http_file(
-    name = "org_mozilla_firefox_mac",
-    sha256 = "c068696c69af2da2b916e33e93755f7dda478fa6e9d17a60643cf2009bbaf8e2",
-    url = "https://ftp.mozilla.org/pub/firefox/releases/49.0/firefox-49.0.mac-x86_64.sdk.tar.bz2",
-)
-
-http_file(
-    name = "org_mozilla_geckodriver_linux",
-    sha256 = "dee64571aefb5ef0279df7358d5f74fdf19a316adbab13c67e3c2d2c14da9e97",
-    url = "https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz",
-)
-
-http_file(
-    name = "org_mozilla_geckodriver_mac",
-    sha256 = "acb05a7671948167e6c1b6930f32ea71dcaa2c12b2c2963e829c7b232f9125d0",
-    url = "https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-macos.tar.gz",
-)
-
-http_file(
-    name = "org_phantomjs_linux",
-    sha256 = "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f",
-    url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2",
-)
-
-http_file(
-    name = "org_phantomjs_mac",
-    sha256 = "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1",
-    url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
+platform_http_file(
+    name = "org_phantomjs",
+    amd64_sha256 = "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f",
+    amd64_url = "http://bazel-mirror.storage.googleapis.com/bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2",
+    macos_sha256 = "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1",
+    macos_url = "http://bazel-mirror.storage.googleapis.com/bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
 )

--- a/browsers/BUILD
+++ b/browsers/BUILD
@@ -32,10 +32,7 @@ config_setting(
 
 web_test_archive(
     name = "chromedriver",
-    archive = select({
-        ":linux": "@org_chromium_chromedriver_linux//file",
-        ":mac": "@org_chromium_chromedriver_mac//file",
-    }),
+    archive = "@org_chromium_chromedriver//file",
     named_files = {
         "CHROMEDRIVER": "chromedriver",
     },
@@ -43,10 +40,7 @@ web_test_archive(
 
 web_test_archive(
     name = "chrome",
-    archive = select({
-        ":linux": "@com_google_chrome_linux//file",
-        ":mac": "@com_google_chrome_mac//file",
-    }),
+    archive = "@com_google_chrome//file",
     named_files = select({
         ":linux": {
             "CHROME": "chrome-precise64/chrome",
@@ -59,10 +53,7 @@ web_test_archive(
 
 web_test_archive(
     name = "firefox",
-    archive = select({
-        ":linux": "@org_mozilla_firefox_linux//file",
-        ":mac": "@org_mozilla_firefox_mac//file",
-    }),
+    archive = "@org_mozilla_firefox//file",
     named_files = select({
         ":linux": {
             "FIREFOX": "firefox-sdk/bin/firefox",
@@ -75,10 +66,7 @@ web_test_archive(
 
 web_test_archive(
     name = "geckodriver",
-    archive = select({
-        ":linux": "@org_mozilla_geckodriver_linux//file",
-        ":mac": "@org_mozilla_geckodriver_mac//file",
-    }),
+    archive = "@org_mozilla_geckodriver//file",
     named_files = {
         "GECKODRIVER": "geckodriver",
     },
@@ -86,10 +74,7 @@ web_test_archive(
 
 web_test_archive(
     name = "phantomjs_bin",
-    archive = select({
-        ":linux": "@org_phantomjs_linux//file",
-        ":mac": "@org_phantomjs_mac//file",
-    }),
+    archive = "@org_phantomjs//file",
     named_files = select({
         ":linux": {
             "PHANTOMJS": "phantomjs-2.1.1-linux-x86_64/bin/phantomjs",

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -34,7 +34,7 @@ def _browser_impl(ctx):
 
   merge_metadata_files(
       ctx=ctx,
-      merger=ctx.executable._merger,
+      merger=ctx.executable.merger,
       output=ctx.outputs.web_test_metadata,
       inputs=metadata_files)
 
@@ -62,11 +62,11 @@ browser = rule(
             attr.string_dict(default={}),
         "required_tags":
             attr.string_list(default=[]),
-        "_merger":
+        "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//external:web_test_merger")),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},)
 """Defines a browser configuration for use with web_test.

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -27,10 +27,7 @@ load(
 def _browser_impl(ctx):
   """Implementation of the browser rule."""
   patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
-  create_metadata_file(
-      ctx=ctx,
-      output=patch,
-      browser_label=ctx.label,)
+  create_metadata_file(ctx=ctx, output=patch, browser_label=ctx.label)
 
   metadata_files = get_metadata_files(ctx,
                                       ["data"]) + [ctx.file.metadata, patch]
@@ -39,7 +36,7 @@ def _browser_impl(ctx):
       ctx=ctx,
       merger=ctx.executable.merger,
       output=ctx.outputs.web_test_metadata,
-      inputs=metadata_files,)
+      inputs=metadata_files)
 
   return struct(
       disabled=ctx.attr.disabled,
@@ -47,34 +44,31 @@ def _browser_impl(ctx):
       required_tags=ctx.attr.required_tags,
       runfiles=build_runfiles(
           ctx, files=[ctx.outputs.web_test_metadata]),
-      web_test_metadata=ctx.outputs.web_test_metadata,)
+      web_test_metadata=ctx.outputs.web_test_metadata)
 
 
 browser = rule(
     attrs={
         "metadata":
             attr.label(
-                mandatory=True,
-                allow_single_file=True,
-                cfg="data",),
+                mandatory=True, allow_single_file=True, cfg="data"),
         "data":
             attr.label_list(
-                allow_files=True,
-                cfg="data",),
+                allow_files=True, cfg="data"),
         "disabled":
             attr.string(),
         "environment":
-            attr.string_dict(default={}),
+            attr.string_dict(),
         "required_tags":
-            attr.string_list(default=[]),
+            attr.string_list(),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger"),),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_browser_impl,)
+    implementation=_browser_impl)
 """Defines a browser configuration for use with web_test.
 
 Args:

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -27,7 +27,10 @@ load(
 def _browser_impl(ctx):
   """Implementation of the browser rule."""
   patch = ctx.new_file("%s.tmp.json" % ctx.label.name)
-  create_metadata_file(ctx=ctx, output=patch, browser_label=ctx.label)
+  create_metadata_file(
+      ctx=ctx,
+      output=patch,
+      browser_label=ctx.label,)
 
   metadata_files = get_metadata_files(ctx,
                                       ["data"]) + [ctx.file.metadata, patch]
@@ -36,7 +39,7 @@ def _browser_impl(ctx):
       ctx=ctx,
       merger=ctx.executable.merger,
       output=ctx.outputs.web_test_metadata,
-      inputs=metadata_files)
+      inputs=metadata_files,)
 
   return struct(
       disabled=ctx.attr.disabled,

--- a/web/internal/browser.bzl
+++ b/web/internal/browser.bzl
@@ -48,14 +48,16 @@ def _browser_impl(ctx):
 
 
 browser = rule(
-    implementation=_browser_impl,
     attrs={
         "metadata":
             attr.label(
-                mandatory=True, allow_single_file=True, cfg="data"),
+                mandatory=True,
+                allow_single_file=True,
+                cfg="data",),
         "data":
             attr.label_list(
-                allow_files=True, cfg="data"),
+                allow_files=True,
+                cfg="data",),
         "disabled":
             attr.string(),
         "environment":
@@ -66,9 +68,10 @@ browser = rule(
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger")),
+                default=Label("//go/metadata:merger"),),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},)
+    outputs={"web_test_metadata": "%{name}.gen.json"},
+    implementation=_browser_impl,)
 """Defines a browser configuration for use with web_test.
 
 Args:

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -38,10 +38,10 @@ def _impl(repository_ctx):
 
 
 platform_http_file = repository_rule(
-    implementation=_impl,
     attrs={
         "amd64_url": attr.string(),
         "amd64_sha256": attr.string(),
         "macos_url": attr.string(),
         "macos_sha256": attr.string(),
-    })
+    },
+    implementation=_impl,)

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -1,0 +1,47 @@
+# -*- mode: python; -*-
+#
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Downloads files based on local platform."""
+
+
+def _impl(repository_ctx):
+  if repository_ctx.os.name.lower().startswith("mac os"):
+    url = repository_ctx.attr.macos_url
+    sha256 = repository_ctx.attr.macos_sha256
+  else:
+    url = repository_ctx.attr.amd64_url
+    sha256 = repository_ctx.attr.amd64_sha256
+  basename = url[url.rindex("/") + 1:]
+  repository_ctx.download(url, basename, sha256)
+  repository_ctx.symlink(basename, "file/" + basename)
+  repository_ctx.file("file/BUILD", "\n".join([
+      ("# DO NOT EDIT: automatically generated BUILD file for " +
+       "platform_http_file rule " + repository_ctx.name),
+      "filegroup(",
+      "    name = 'file',",
+      "    srcs = ['%s']," % basename,
+      "    visibility = ['//visibility:public'],",
+      ")",
+  ]))
+
+
+platform_http_file = repository_rule(
+    implementation=_impl,
+    attrs={
+        "amd64_url": attr.string(),
+        "amd64_sha256": attr.string(),
+        "macos_url": attr.string(),
+        "macos_sha256": attr.string(),
+    })

--- a/web/internal/platform_http_file.bzl
+++ b/web/internal/platform_http_file.bzl
@@ -44,4 +44,4 @@ platform_http_file = repository_rule(
         "macos_url": attr.string(),
         "macos_sha256": attr.string(),
     },
-    implementation=_impl,)
+    implementation=_impl)

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -16,8 +16,12 @@
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:shared.bzl", "build_runfiles", "get_metadata_files",
-     "merge_metadata_files", "path")
+load(
+    "//web/internal:shared.bzl",
+    "build_runfiles",
+    "get_metadata_files",
+    "merge_metadata_files",
+    "path",)
 
 
 def _web_test_impl(ctx):
@@ -103,12 +107,12 @@ def _generate_default_test(ctx):
 
 
 web_test = rule(
-    implementation=_web_test_impl,
-    test=True,
     attrs={
         "test":
             attr.label(
-                cfg="data", executable=True, mandatory=True),
+                cfg="data",
+                executable=True,
+                mandatory=True,),
         "browser":
             attr.label(
                 cfg="data",
@@ -118,37 +122,40 @@ web_test = rule(
                     "environment",
                     "required_tags",
                     "web_test_metadata",
-                ]),
+                ],),
         "config":
             attr.label(
                 cfg="data",
                 default=Label("//web:default_config"),
-                providers=["web_test_metadata"]),
+                providers=["web_test_metadata"],),
         "data":
             attr.label_list(
-                allow_files=True, cfg="data"),
+                allow_files=True,
+                cfg="data",),
         "merger":
             attr.label(
                 cfg="host",
                 executable=True,
-                default=Label("//go/metadata:merger")),
+                default=Label("//go/metadata:merger"),),
         "launcher":
             attr.label(
                 cfg="data",
                 executable=True,
-                default=Label("//go/launcher:main")),
+                default=Label("//go/launcher:main"),),
         "web_test_template":
             attr.label(
                 allow_files=True,
                 single_file=True,
-                default=Label("//web/internal:web_test.sh.template")),
+                default=Label("//web/internal:web_test.sh.template"),),
         "noop_web_test_template":
             attr.label(
                 allow_files=True,
                 single_file=True,
-                default=Label("//web/internal:noop_web_test.sh.template")),
+                default=Label("//web/internal:noop_web_test.sh.template"),),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},)
+    outputs={"web_test_metadata": "%{name}.gen.json"},
+    test=True,
+    implementation=_web_test_impl,)
 """Runs a provided test against a provided browser configuration.
 
 Args:

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -41,7 +41,8 @@ Why was this browser disabled?
 
   if missing_tags:
     fail("Browser {browser} requires tags {tags} that are missing.".format(
-        browser=ctx.attr.browser.label, tags=missing_tags))
+        browser=ctx.attr.browser.label,
+        tags=missing_tags,))
 
   return _generate_default_test(ctx)
 
@@ -61,7 +62,9 @@ def _generate_noop_test(ctx, reason, status=0):
   else:
     success = "passes"
 
-  ctx.file_action(content="", output=ctx.outputs.web_test_metadata)
+  ctx.file_action(
+      content="",
+      output=ctx.outputs.web_test_metadata,)
 
   ctx.template_action(
       template=ctx.file.noop_web_test_template,
@@ -71,7 +74,7 @@ def _generate_noop_test(ctx, reason, status=0):
           "%TEMPLATED_reason%": reason,
           "%TEMPLATED_status%": str(status),
       },
-      executable=True)
+      executable=True,)
 
   return struct()
 
@@ -98,12 +101,13 @@ def _generate_default_test(ctx):
           "%TEMPLATED_metadata%": path(ctx, ctx.outputs.web_test_metadata),
           "%TEMPLATED_test%": path(ctx, ctx.executable.test),
       },
-      executable=True)
+      executable=True,)
 
-  return struct(runfiles=build_runfiles(
-      ctx,
-      files=[ctx.outputs.web_test_metadata],
-      deps_attrs=["launcher", "browser", "config", "test"]))
+  return struct(
+      runfiles=build_runfiles(
+          ctx,
+          files=[ctx.outputs.web_test_metadata],
+          deps_attrs=["launcher", "browser", "config", "test"],),)
 
 
 web_test = rule(
@@ -153,7 +157,7 @@ web_test = rule(
                 single_file=True,
                 default=Label("//web/internal:noop_web_test.sh.template"),),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},
+    outputs={"web_test_metadata": "%{name}.gen.json",},
     test=True,
     implementation=_web_test_impl,)
 """Runs a provided test against a provided browser configuration.

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -60,7 +60,7 @@ def _generate_noop_test(ctx, reason, status=0):
   ctx.file_action(content="", output=ctx.outputs.web_test_metadata)
 
   ctx.template_action(
-      template=ctx.file._noop_web_test_template,
+      template=ctx.file.noop_web_test_template,
       output=ctx.outputs.executable,
       substitutions={
           "%TEMPLATED_success%": success,
@@ -77,7 +77,7 @@ def _generate_default_test(ctx):
 
   merge_metadata_files(
       ctx=ctx,
-      merger=ctx.executable._merger,
+      merger=ctx.executable.merger,
       output=ctx.outputs.web_test_metadata,
       inputs=metadata_files,)
 
@@ -86,11 +86,11 @@ def _generate_default_test(ctx):
     env_vars += "export %s=%s\n" % (k, v)
 
   ctx.template_action(
-      template=ctx.file._web_test_template,
+      template=ctx.file.web_test_template,
       output=ctx.outputs.executable,
       substitutions={
           "%TEMPLATED_env_vars%": env_vars,
-          "%TEMPLATED_launcher%": path(ctx, ctx.executable._launcher),
+          "%TEMPLATED_launcher%": path(ctx, ctx.executable.launcher),
           "%TEMPLATED_metadata%": path(ctx, ctx.outputs.web_test_metadata),
           "%TEMPLATED_test%": path(ctx, ctx.executable.test),
       },
@@ -99,7 +99,7 @@ def _generate_default_test(ctx):
   return struct(runfiles=build_runfiles(
       ctx,
       files=[ctx.outputs.web_test_metadata],
-      deps_attrs=["_launcher", "browser", "config", "test"]))
+      deps_attrs=["launcher", "browser", "config", "test"]))
 
 
 web_test = rule(
@@ -122,31 +122,31 @@ web_test = rule(
         "config":
             attr.label(
                 cfg="data",
-                default=Label("//external:web_test_default_config"),
+                default=Label("//web:default_config"),
                 providers=["web_test_metadata"]),
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
-        "_merger":
+        "merger":
             attr.label(
                 cfg="host",
                 executable=True,
-                default=Label("//external:web_test_merger")),
-        "_launcher":
+                default=Label("//go/metadata:merger")),
+        "launcher":
             attr.label(
                 cfg="data",
                 executable=True,
-                default=Label("//external:web_test_launcher")),
-        "_web_test_template":
+                default=Label("//go/launcher:main")),
+        "web_test_template":
             attr.label(
                 allow_files=True,
                 single_file=True,
-                default=Label("//external:web_test_template")),
-        "_noop_web_test_template":
+                default=Label("//web/internal:web_test.sh.template")),
+        "noop_web_test_template":
             attr.label(
                 allow_files=True,
                 single_file=True,
-                default=Label("//external:noop_web_test_template")),
+                default=Label("//web/internal:noop_web_test.sh.template")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},)
 """Runs a provided test against a provided browser configuration.

--- a/web/internal/web_test.bzl
+++ b/web/internal/web_test.bzl
@@ -41,8 +41,7 @@ Why was this browser disabled?
 
   if missing_tags:
     fail("Browser {browser} requires tags {tags} that are missing.".format(
-        browser=ctx.attr.browser.label,
-        tags=missing_tags,))
+        browser=ctx.attr.browser.label, tags=missing_tags))
 
   return _generate_default_test(ctx)
 
@@ -74,7 +73,7 @@ def _generate_noop_test(ctx, reason, status=0):
           "%TEMPLATED_reason%": reason,
           "%TEMPLATED_status%": str(status),
       },
-      executable=True,)
+      executable=True)
 
   return struct()
 
@@ -86,7 +85,7 @@ def _generate_default_test(ctx):
       ctx=ctx,
       merger=ctx.executable.merger,
       output=ctx.outputs.web_test_metadata,
-      inputs=metadata_files,)
+      inputs=metadata_files)
 
   env_vars = ""
   for k, v in ctx.attr.browser.environment.items():
@@ -101,22 +100,19 @@ def _generate_default_test(ctx):
           "%TEMPLATED_metadata%": path(ctx, ctx.outputs.web_test_metadata),
           "%TEMPLATED_test%": path(ctx, ctx.executable.test),
       },
-      executable=True,)
+      executable=True)
 
-  return struct(
-      runfiles=build_runfiles(
-          ctx,
-          files=[ctx.outputs.web_test_metadata],
-          deps_attrs=["launcher", "browser", "config", "test"],),)
+  return struct(runfiles=build_runfiles(
+      ctx,
+      files=[ctx.outputs.web_test_metadata],
+      deps_attrs=["launcher", "browser", "config", "test"]))
 
 
 web_test = rule(
     attrs={
         "test":
             attr.label(
-                cfg="data",
-                executable=True,
-                mandatory=True,),
+                cfg="data", executable=True, mandatory=True),
         "browser":
             attr.label(
                 cfg="data",
@@ -126,40 +122,39 @@ web_test = rule(
                     "environment",
                     "required_tags",
                     "web_test_metadata",
-                ],),
+                ]),
         "config":
             attr.label(
                 cfg="data",
                 default=Label("//web:default_config"),
-                providers=["web_test_metadata"],),
+                providers=["web_test_metadata"]),
         "data":
             attr.label_list(
-                allow_files=True,
-                cfg="data",),
+                allow_files=True, cfg="data"),
         "merger":
             attr.label(
                 cfg="host",
                 executable=True,
-                default=Label("//go/metadata:merger"),),
+                default=Label("//go/metadata:merger")),
         "launcher":
             attr.label(
                 cfg="data",
                 executable=True,
-                default=Label("//go/launcher:main"),),
+                default=Label("//go/launcher:main")),
         "web_test_template":
             attr.label(
                 allow_files=True,
                 single_file=True,
-                default=Label("//web/internal:web_test.sh.template"),),
+                default=Label("//web/internal:web_test.sh.template")),
         "noop_web_test_template":
             attr.label(
                 allow_files=True,
                 single_file=True,
-                default=Label("//web/internal:noop_web_test.sh.template"),),
+                default=Label("//web/internal:noop_web_test.sh.template")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json",},
     test=True,
-    implementation=_web_test_impl,)
+    implementation=_web_test_impl)
 """Runs a provided test against a provided browser configuration.
 
 Args:

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -19,8 +19,12 @@ such as additional capabilities.
 DO NOT load this file. Use "@io_bazel_rules_web//web:web.bzl".
 """
 
-load("//web/internal:shared.bzl", "build_runfiles", "create_metadata_file",
-     "get_metadata_files", "merge_metadata_files")
+load(
+    "//web/internal:shared.bzl",
+    "build_runfiles",
+    "create_metadata_file",
+    "get_metadata_files",
+    "merge_metadata_files",)
 
 
 def _web_test_config_impl(ctx):
@@ -47,7 +51,6 @@ def _web_test_config_impl(ctx):
 
 
 web_test_config = rule(
-    implementation=_web_test_config_impl,
     attrs={
         "configs":
             attr.label_list(providers=["web_test_metadata"]),
@@ -55,14 +58,16 @@ web_test_config = rule(
             attr.label(allow_single_file=True),
         "data":
             attr.label_list(
-                allow_files=True, cfg="data"),
+                allow_files=True,
+                cfg="data",),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger")),
+                default=Label("//go/metadata:merger"),),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},)
+    outputs={"web_test_metadata": "%{name}.gen.json"},
+    implementation=_web_test_config_impl,)
 """A browser-independent configuration that can be used across multiple web_tests.
 
 Args:

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -34,7 +34,7 @@ def _web_test_config_impl(ctx):
   if metadata_files:
     merge_metadata_files(
         ctx=ctx,
-        merger=ctx.executable._merger,
+        merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
         inputs=metadata_files)
   else:
@@ -56,11 +56,11 @@ web_test_config = rule(
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
-        "_merger":
+        "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//external:web_test_merger")),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},)
 """A browser-independent configuration that can be used across multiple web_tests.

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -40,7 +40,7 @@ def _web_test_config_impl(ctx):
         ctx=ctx,
         merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
-        inputs=metadata_files)
+        inputs=metadata_files,)
   else:
     create_metadata_file(ctx=ctx, output=ctx.outputs.web_test_metadata)
 
@@ -58,7 +58,7 @@ web_test_config = rule(
             attr.label(allow_single_file=True),
         "data":
             attr.label_list(
-                allow_files=True,
+                llow_files=True,
                 cfg="data",),
         "merger":
             attr.label(

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -58,7 +58,7 @@ web_test_config = rule(
             attr.label(allow_single_file=True),
         "data":
             attr.label_list(
-                llow_files=True, cfg="data"),
+                allow_files=True, cfg="data"),
         "merger":
             attr.label(
                 executable=True,

--- a/web/internal/web_test_config.bzl
+++ b/web/internal/web_test_config.bzl
@@ -40,14 +40,14 @@ def _web_test_config_impl(ctx):
         ctx=ctx,
         merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
-        inputs=metadata_files,)
+        inputs=metadata_files)
   else:
     create_metadata_file(ctx=ctx, output=ctx.outputs.web_test_metadata)
 
   return struct(
       runfiles=build_runfiles(
           ctx, files=[ctx.outputs.web_test_metadata]),
-      web_test_metadata=ctx.outputs.web_test_metadata,)
+      web_test_metadata=ctx.outputs.web_test_metadata)
 
 
 web_test_config = rule(
@@ -58,16 +58,15 @@ web_test_config = rule(
             attr.label(allow_single_file=True),
         "data":
             attr.label_list(
-                llow_files=True,
-                cfg="data",),
+                llow_files=True, cfg="data"),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger"),),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_web_test_config_impl,)
+    implementation=_web_test_config_impl)
 """A browser-independent configuration that can be used across multiple web_tests.
 
 Args:

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -42,14 +42,14 @@ def _web_test_named_executable_impl(ctx):
         ctx=ctx,
         merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
-        inputs=metadata_files,)
+        inputs=metadata_files)
 
   return struct(
       runfiles=build_runfiles(
           ctx=ctx,
           files=[ctx.outputs.web_test_metadata],
-          deps_attrs=["executable"],),
-      web_test_metadata=ctx.outputs.web_test_metadata,)
+          deps_attrs=["executable"]),
+      web_test_metadata=ctx.outputs.web_test_metadata)
 
 
 web_test_named_executable = rule(
@@ -58,19 +58,15 @@ web_test_named_executable = rule(
             attr.string(),
         "executable":
             attr.label(
-                allow_files=True,
-                executable=True,
-                cfg="data",
-                mandatory=True,),
+                allow_files=True, executable=True, cfg="data", mandatory=True),
         "data":
             attr.label_list(
-                allow_files=True,
-                cfg="data",),
+                allow_files=True, cfg="data"),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger"),),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
     implementation=_web_test_named_executable_impl,)

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -40,7 +40,7 @@ def _web_test_named_executable_impl(ctx):
     metadata_files += [patch]
     merge_metadata_files(
         ctx=ctx,
-        merger=ctx.executable._merger,
+        merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
         inputs=metadata_files,)
 
@@ -63,11 +63,11 @@ web_test_named_executable = rule(
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
-        "_merger":
+        "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//external:web_test_merger")),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},)
 """Defines a executable that can be located by name.

--- a/web/internal/web_test_named_executable.bzl
+++ b/web/internal/web_test_named_executable.bzl
@@ -53,23 +53,27 @@ def _web_test_named_executable_impl(ctx):
 
 
 web_test_named_executable = rule(
-    implementation=_web_test_named_executable_impl,
     attrs={
         "alt_name":
             attr.string(),
         "executable":
             attr.label(
-                allow_files=True, executable=True, cfg="data", mandatory=True),
+                allow_files=True,
+                executable=True,
+                cfg="data",
+                mandatory=True,),
         "data":
             attr.label_list(
-                allow_files=True, cfg="data"),
+                allow_files=True,
+                cfg="data",),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger")),
+                default=Label("//go/metadata:merger"),),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},)
+    outputs={"web_test_metadata": "%{name}.gen.json"},
+    implementation=_web_test_named_executable_impl,)
 """Defines a executable that can be located by name.
 
 Args:

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -53,23 +53,26 @@ def _web_test_named_file_impl(ctx):
 
 
 web_test_named_file = rule(
-    implementation=_web_test_named_file_impl,
     attrs={
         "alt_name":
             attr.string(),
         "file":
             attr.label(
-                allow_single_file=True, cfg="data", mandatory=True),
+                allow_single_file=True,
+                cfg="data",
+                mandatory=True,),
         "data":
             attr.label_list(
-                allow_files=True, cfg="data"),
+                allow_files=True,
+                cfg="data",),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger")),
+                default=Label("//go/metadata:merger"),),
     },
-    outputs={"web_test_metadata": "%{name}.gen.json"},)
+    outputs={"web_test_metadata": "%{name}.gen.json"},
+    implementation=_web_test_named_file_impl,)
 """Defines a executable that can be located by name.
 
 Args:

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -42,14 +42,12 @@ def _web_test_named_file_impl(ctx):
         ctx=ctx,
         merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
-        inputs=metadata_files,)
+        inputs=metadata_files)
 
   return struct(
       runfiles=build_runfiles(
-          ctx=ctx,
-          files=[ctx.outputs.web_test_metadata],
-          deps_attrs=["file"],),
-      web_test_metadata=ctx.outputs.web_test_metadata,)
+          ctx=ctx, files=[ctx.outputs.web_test_metadata], deps_attrs=["file"]),
+      web_test_metadata=ctx.outputs.web_test_metadata)
 
 
 web_test_named_file = rule(
@@ -58,21 +56,18 @@ web_test_named_file = rule(
             attr.string(),
         "file":
             attr.label(
-                allow_single_file=True,
-                cfg="data",
-                mandatory=True,),
+                allow_single_file=True, cfg="data", mandatory=True),
         "data":
             attr.label_list(
-                allow_files=True,
-                cfg="data",),
+                allow_files=True, cfg="data"),
         "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//go/metadata:merger"),),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},
-    implementation=_web_test_named_file_impl,)
+    implementation=_web_test_named_file_impl)
 """Defines a executable that can be located by name.
 
 Args:

--- a/web/internal/web_test_named_file.bzl
+++ b/web/internal/web_test_named_file.bzl
@@ -40,7 +40,7 @@ def _web_test_named_file_impl(ctx):
     metadata_files += [patch]
     merge_metadata_files(
         ctx=ctx,
-        merger=ctx.executable._merger,
+        merger=ctx.executable.merger,
         output=ctx.outputs.web_test_metadata,
         inputs=metadata_files,)
 
@@ -63,11 +63,11 @@ web_test_named_file = rule(
         "data":
             attr.label_list(
                 allow_files=True, cfg="data"),
-        "_merger":
+        "merger":
             attr.label(
                 executable=True,
                 cfg="host",
-                default=Label("//external:web_test_merger")),
+                default=Label("//go/metadata:merger")),
     },
     outputs={"web_test_metadata": "%{name}.gen.json"},)
 """Defines a executable that can be located by name.

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -30,7 +30,7 @@ def web_test_repositories(java=False,
         build_file=str(Label("//build_files:BUILD.gorilla_mux")),
         url="https://github.com/gorilla/mux/archive/cf79e51a62d8219d52060dfc1b4e810414ba2d15.tar.gz",
         sha256="80077e14b2f0f8f2796b6bfcf5c8e41e148e3c8c45b4c20d1e6856b348d5efb7",
-        strip_prefix="mux-cf79e51a62d8219d52060dfc1b4e810414ba2d15")
+        strip_prefix="mux-cf79e51a62d8219d52060dfc1b4e810414ba2d15",)
 
   if not omit_org_seleniumhq_server:
     native.http_jar(
@@ -73,7 +73,7 @@ def web_test_repositories(java=False,
           build_file=str(Label("//build_files:BUILD.selenium_go")),
           url="https://github.com/tebeka/selenium/archive/v0.9.2.tar.gz",
           sha256="c5f21652eda6230ee8bb5f9f02b740fa8d8b22c0cddc832ec666a7654bb0d1a4",
-          strip_prefix="selenium-0.9.2")
+          strip_prefix="selenium-0.9.2",)
 
   if python:
     if not omit_org_seleniumhq_py:

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -30,13 +30,13 @@ def web_test_repositories(java=False,
         build_file=str(Label("//build_files:BUILD.gorilla_mux")),
         url="https://github.com/gorilla/mux/archive/cf79e51a62d8219d52060dfc1b4e810414ba2d15.tar.gz",
         sha256="80077e14b2f0f8f2796b6bfcf5c8e41e148e3c8c45b4c20d1e6856b348d5efb7",
-        strip_prefix="mux-cf79e51a62d8219d52060dfc1b4e810414ba2d15",)
+        strip_prefix="mux-cf79e51a62d8219d52060dfc1b4e810414ba2d15")
 
   if not omit_org_seleniumhq_server:
     native.http_jar(
         name="org_seleniumhq_server",
         sha256="f5ada04a651ba7ec70fcbc68bd4a59342a928ef7dce858ec594a8d5c49576ace",
-        url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-server-standalone-3.0.0-beta3.jar",
+        url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-server-standalone-3.0.0-beta3.jar"
     )
 
   if java:
@@ -45,26 +45,26 @@ def web_test_repositories(java=False,
           name="org_seleniumhq_java",
           build_file=str(Label("//build_files:BUILD.selenium_java")),
           sha256="a26a449388abd46d1e152771e3641859ac4acee9c0ea24a101ca369048a81ecb",
-          url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-java-3.0.0-beta3.zip",
+          url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-java-3.0.0-beta3.zip"
       )
 
     if not omit_org_json_json:
       native.maven_jar(
           name="org_json_json",
           artifact="org.json:json:20160810",
-          sha1="aca5eb39e2a12fddd6c472b240afe9ebea3a6733",)
+          sha1="aca5eb39e2a12fddd6c472b240afe9ebea3a6733")
 
     if not omit_com_google_code_findbugs_jsr305:
       native.maven_jar(
           name="com_google_code_findbugs_jsr305",
           artifact="com.google.code.findbugs:jsr305:3.0.1",
-          sha1="f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",)
+          sha1="f7be08ec23c21485b9b5a1cf1654c2ec8c58168d")
 
     if not omit_com_google_guava_guava:
       native.maven_jar(
           name="com_google_guava_guava",
           artifact="com.google.guava:guava:19.0",
-          sha1="6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9",)
+          sha1="6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9")
 
   if go:
     if not omit_com_github_tebeka_selenium:
@@ -73,7 +73,7 @@ def web_test_repositories(java=False,
           build_file=str(Label("//build_files:BUILD.selenium_go")),
           url="https://github.com/tebeka/selenium/archive/v0.9.2.tar.gz",
           sha256="c5f21652eda6230ee8bb5f9f02b740fa8d8b22c0cddc832ec666a7654bb0d1a4",
-          strip_prefix="selenium-0.9.2",)
+          strip_prefix="selenium-0.9.2")
 
   if python:
     if not omit_org_seleniumhq_py:
@@ -82,5 +82,5 @@ def web_test_repositories(java=False,
           build_file=str(Label("//build_files:BUILD.selenium_py")),
           sha256="0705803349964c7a2a144f1796a5d29905fe2a09931b2bb945ee0cb4deab75d7",
           strip_prefix="selenium-3.0.1/py",
-          url="https://pypi.python.org/packages/3a/a3/e4ab60a0229a85f468a36367bc0672a4bca2720f24391eda33704a5f0ad5/selenium-3.0.1.tar.gz",
+          url="https://pypi.python.org/packages/3a/a3/e4ab60a0229a85f468a36367bc0672a4bca2720f24391eda33704a5f0ad5/selenium-3.0.1.tar.gz"
       )

--- a/web/repositories.bzl
+++ b/web/repositories.bzl
@@ -13,84 +13,74 @@
 # limitations under the License.
 
 
-def web_test_repositories(
-    prefix="@io_bazel_rules_web",
-    java=False,
-    go=False,
-    python=False,
-    launcher="@io_bazel_rules_web//go/launcher:main",
-    merger="@io_bazel_rules_web//go/metadata:merger",
-    default_config="@io_bazel_rules_web//web:default_config",
-    web_test_template="@io_bazel_rules_web//web/internal:web_test.sh.template",
-    noop_web_test_template="@io_bazel_rules_web//web/internal:noop_web_test.sh.template",
-):
-  native.new_git_repository(
-      name="com_github_gorilla_mux",
-      build_file=prefix + "//build_files:BUILD.gorilla_mux",
-      commit="cf79e51a62d8219d52060dfc1b4e810414ba2d15",
-      remote="https://github.com/gorilla/mux.git",)
+def web_test_repositories(java=False,
+                          go=False,
+                          python=False,
+                          omit_com_github_gorilla_mux=False,
+                          omit_org_seleniumhq_server=False,
+                          omit_org_seleniumhq_java=False,
+                          omit_org_json_json=False,
+                          omit_com_google_code_findbugs_jsr305=False,
+                          omit_com_google_guava_guava=False,
+                          omit_com_github_tebeka_selenium=False,
+                          omit_org_seleniumhq_py=False):
+  if not omit_com_github_gorilla_mux:
+    native.new_http_archive(
+        name="com_github_gorilla_mux",
+        build_file=str(Label("//build_files:BUILD.gorilla_mux")),
+        url="https://github.com/gorilla/mux/archive/cf79e51a62d8219d52060dfc1b4e810414ba2d15.tar.gz",
+        sha256="80077e14b2f0f8f2796b6bfcf5c8e41e148e3c8c45b4c20d1e6856b348d5efb7",
+        strip_prefix="mux-cf79e51a62d8219d52060dfc1b4e810414ba2d15")
 
-  native.http_jar(
-      name="org_seleniumhq_server",
-      sha256="f5ada04a651ba7ec70fcbc68bd4a59342a928ef7dce858ec594a8d5c49576ace",
-      url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-server-standalone-3.0.0-beta3.jar",
-  )
-
-  native.bind(
-      name="web_test_launcher",
-      actual=launcher,)
-
-  native.bind(
-      name="web_test_merger",
-      actual=merger,)
-
-  native.bind(
-      name="web_test_default_config",
-      actual=default_config,)
-
-  native.bind(
-      name="web_test_template",
-      actual=web_test_template,)
-
-  native.bind(
-      name="noop_web_test_template",
-      actual=noop_web_test_template,)
+  if not omit_org_seleniumhq_server:
+    native.http_jar(
+        name="org_seleniumhq_server",
+        sha256="f5ada04a651ba7ec70fcbc68bd4a59342a928ef7dce858ec594a8d5c49576ace",
+        url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-server-standalone-3.0.0-beta3.jar",
+    )
 
   if java:
-    native.new_http_archive(
-        name="org_seleniumhq_java",
-        build_file=prefix + "//build_files:BUILD.selenium_java",
-        sha256="a26a449388abd46d1e152771e3641859ac4acee9c0ea24a101ca369048a81ecb",
-        url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-java-3.0.0-beta3.zip",
-    )
+    if not omit_org_seleniumhq_java:
+      native.new_http_archive(
+          name="org_seleniumhq_java",
+          build_file=str(Label("//build_files:BUILD.selenium_java")),
+          sha256="a26a449388abd46d1e152771e3641859ac4acee9c0ea24a101ca369048a81ecb",
+          url="http://selenium-release.storage.googleapis.com/3.0-beta3/selenium-java-3.0.0-beta3.zip",
+      )
 
-    native.maven_jar(
-        name="org_json_json",
-        artifact="org.json:json:20160810",
-        sha1="aca5eb39e2a12fddd6c472b240afe9ebea3a6733",)
+    if not omit_org_json_json:
+      native.maven_jar(
+          name="org_json_json",
+          artifact="org.json:json:20160810",
+          sha1="aca5eb39e2a12fddd6c472b240afe9ebea3a6733",)
 
-    native.maven_jar(
-        name="com_google_code_findbugs_jsr305",
-        artifact="com.google.code.findbugs:jsr305:3.0.1",
-        sha1="f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",)
+    if not omit_com_google_code_findbugs_jsr305:
+      native.maven_jar(
+          name="com_google_code_findbugs_jsr305",
+          artifact="com.google.code.findbugs:jsr305:3.0.1",
+          sha1="f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",)
 
-    native.maven_jar(
-        name="com_google_guava_guava",
-        artifact="com.google.guava:guava:19.0",
-        sha1="6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9",)
+    if not omit_com_google_guava_guava:
+      native.maven_jar(
+          name="com_google_guava_guava",
+          artifact="com.google.guava:guava:19.0",
+          sha1="6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9",)
 
   if go:
-    native.new_git_repository(
-        name="com_github_tebeka_selenium",
-        build_file=prefix + "//build_files:BUILD.selenium_go",
-        remote="https://github.com/tebeka/selenium.git",
-        tag="v0.8.5",)
+    if not omit_com_github_tebeka_selenium:
+      native.new_http_archive(
+          name="com_github_tebeka_selenium",
+          build_file=str(Label("//build_files:BUILD.selenium_go")),
+          url="https://github.com/tebeka/selenium/archive/v0.9.2.tar.gz",
+          sha256="c5f21652eda6230ee8bb5f9f02b740fa8d8b22c0cddc832ec666a7654bb0d1a4",
+          strip_prefix="selenium-0.9.2")
 
   if python:
-    native.new_http_archive(
-        name="org_seleniumhq_py",
-        build_file=prefix + "//build_files:BUILD.selenium_py",
-        sha256="0705803349964c7a2a144f1796a5d29905fe2a09931b2bb945ee0cb4deab75d7",
-        strip_prefix="selenium-3.0.1/py",
-        url="https://pypi.python.org/packages/3a/a3/e4ab60a0229a85f468a36367bc0672a4bca2720f24391eda33704a5f0ad5/selenium-3.0.1.tar.gz",
-    )
+    if not omit_org_seleniumhq_py:
+      native.new_http_archive(
+          name="org_seleniumhq_py",
+          build_file=str(Label("//build_files:BUILD.selenium_py")),
+          sha256="0705803349964c7a2a144f1796a5d29905fe2a09931b2bb945ee0cb4deab75d7",
+          strip_prefix="selenium-3.0.1/py",
+          url="https://pypi.python.org/packages/3a/a3/e4ab60a0229a85f468a36367bc0672a4bca2720f24391eda33704a5f0ad5/selenium-3.0.1.tar.gz",
+      )


### PR DESCRIPTION
* No longer use bind for configuration. Instead make the rule
  attributes that depended on these bind statements public.
* Remove usages of git_repository.
* Make the set of repositories loaded by web_test_repositories fully
  configurable.
* Switch from platform-specific repositories to repositories that get
  configured based on the current platform.