### PR TITLE
Remove testonly from a lot of targets

### DIFF
--- a/browsers/BUILD
+++ b/browsers/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("//web:web.bzl", "browser", "web_test_archive", "web_test_named_executable")
 
 config_setting(

--- a/build_files/BUILD
+++ b/build_files/BUILD
@@ -1,5 +1,3 @@
-package(default_testonly = True)
-
 exports_files(
     glob(["BUILD.*"]),
     visibility = ["//visibility:public"],

--- a/doc/BUILD
+++ b/doc/BUILD
@@ -1,5 +1,3 @@
-package(default_testonly = True)
-
 load("@io_bazel_skydoc//skylark:skylark.bzl", "skylark_doc")
 
 skylark_doc(

--- a/go/BUILD
+++ b/go/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = True)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//web:web.bzl", "web_test", "web_test_suite")
 

--- a/go/launcher/BUILD
+++ b/go/launcher/BUILD
@@ -15,8 +15,6 @@ visibility = ["//go:go_packages"]  # Copyright 2016 Google Inc.
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(

--- a/go/launcher/environments/BUILD
+++ b/go/launcher/environments/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/go/launcher/proxy/BUILD
+++ b/go/launcher/proxy/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/go/launcher/services/BUILD
+++ b/go/launcher/services/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/go/metadata/BUILD
+++ b/go/metadata/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_binary(

--- a/go/metadata/testdata/BUILD
+++ b/go/metadata/testdata/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 exports_files(
     glob(["**"]),
     visibility = ["//go/metadata:__pkg__"],

--- a/go/util/BUILD
+++ b/go/util/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(

--- a/java/BUILD
+++ b/java/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("//web:web.bzl", "web_test_named_executable")
 
 java_binary(

--- a/java/com/google/testing/util/BUILD
+++ b/java/com/google/testing/util/BUILD
@@ -15,7 +15,6 @@
 ################################################################################
 #
 package(
-    default_testonly = 1,
     default_visibility = ["//visibility:public"],
 )
 

--- a/java/com/google/testing/web/BUILD
+++ b/java/com/google/testing/web/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 java_library(
     name = "web",
     srcs = glob(["*.java"]),

--- a/javatests/com/google/testing/web/BUILD
+++ b/javatests/com/google/testing/web/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = True)
-
 load("//web:web.bzl", "web_test", "web_test_suite")
 
 java_test(

--- a/testing/web/BUILD
+++ b/testing/web/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = 1)
-
 load("//web:web.bzl", "web_test", "web_test_suite")
 
 py_library(

--- a/web/BUILD
+++ b/web/BUILD
@@ -14,13 +14,12 @@
 #
 ################################################################################
 #
-package(default_testonly = True)
-
 load(":web.bzl", "web_test_config")
 
 web_test_config(
     name = "default_config",
     visibility = ["//visibility:public"],
+    testonly = 0,
 )
 
 exports_files(

--- a/web/internal/BUILD
+++ b/web/internal/BUILD
@@ -14,8 +14,6 @@
 #
 ################################################################################
 #
-package(default_testonly = True)
-
 exports_files(
     glob(["*.bzl"]),
     visibility = [


### PR DESCRIPTION
Fixing the testonly actually requires to be able to set testonly on bind
or to remove all bind (I would recommend the latest). Next version of
Bazel will be fixed to correctly enforce testonly so I recommend merging
that change for now, then fix the external bindings.

Tested with `bazel build ...`

Tracking bug: bazelbuild/bazel#1967

/cc @kchodorow fyi external does not support testonly...